### PR TITLE
Rely on remote image to fix breaking bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   myos:
     container_name: '${NAME:-default}'
-    image: 'myos:${TAG:-latest}'
+    image: 'rylandg/myos:${TAG:-latest}'
     tty: true
     volumes:
       -  "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
## Before this PR
The compose file relied on a local image

## After this PR
The compose file relies on the remote dockerhub version